### PR TITLE
Don't publish tests to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+perf


### PR DESCRIPTION
In order to keep the library smaller, don't publish stuff to npm that's not used in production.

When checked out, the entire bignumber.js directory is about 6.1 MB, out of which the test and perf directories take up about 6 MB.  
