### PR TITLE
Add source compilation to build step.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "license": "MIT",
   "scripts": {
     "test": "node ./test/every-test.js",
-    "build": "uglifyjs bignumber.js -c -m -o bignumber.min.js --preamble '/* bignumber.js v2.0.2 https://github.com/MikeMcl/bignumber.js/LICENCE */'"
+    "build": "uglifyjs bignumber.js --source-map doc/bignumber.js.map -c -m -o bignumber.min.js --preamble '/* bignumber.js v2.0.2 https://github.com/MikeMcl/bignumber.js/LICENCE */'"
   }
 }


### PR DESCRIPTION
This adds a .map file in the docs directory, allowing users to be
able to use sourcemaps when in a supported enviroment.

Related #52 