### PR TITLE
Fix README's location of JS map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ then
 
 will create *bignumber.min.js*.
 
-A source map will also be created in the *doc* directory.
+A source map will also be created in the root directory.
 
 ## Feedback
 


### PR DESCRIPTION
The README says that after building the map file will be available
in the doc directory.  This isn't true after commit SHA
3661d1caf389955e52ae93d4f451a8c5e7dc3c2d

I had built the library today and noticed this was changed, figured
the README should be updated as well.