### PR TITLE
Fix main file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "type": "git",
     "url": "https://github.com/MikeMcl/bignumber.js.git"
   },
-  "main": "bignumber",
+  "main": "bignumber.js",
   "author": {
     "name": "Michael Mclaughlin",
     "email": "M8ch88l@gmail.com"


### PR DESCRIPTION
#### What's this PR do?
changes the `main` in `package.json` to the correct file

#### Any background context you want to provide?
this module is completely unusable for some front end browser require libraries since the main is referenced incorrectly
