### PR TITLE
Temporarily mimic shift/unshift methods to workaround Safari/Webkit bug

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -728,7 +728,7 @@
 
                         if ( !d ) {
                             ++e;
-                            xc.unshift(1);
+                            xc = [1].concat(xc);
                         }
                     }
                 }
@@ -766,7 +766,7 @@
                     x[i] = temp % base;
                 }
 
-                if (carry) x.unshift(carry);
+                if (carry) x = [carry].concat(x);
 
                 return x;
             }
@@ -869,7 +869,7 @@
                     // Add zeros to make remainder as long as divisor.
                     for ( ; remL < yL; rem[remL++] = 0 );
                     yz = yc.slice();
-                    yz.unshift(0);
+                    yz = [0].concat(yz);
                     yc0 = yc[0];
                     if ( yc[1] >= base / 2 ) yc0++;
                     // Not necessary, but to prevent trial digit n > base, when using base 3.
@@ -940,7 +940,7 @@
                                 prodL = prod.length;
                             }
 
-                            if ( prodL < remL ) prod.unshift(0);
+                            if ( prodL < remL ) prod = [0].concat(prod);
 
                             // Subtract product from remainder.
                             subtract( rem, prod, remL, base );
@@ -1859,7 +1859,7 @@
             }
 
             if (a) {
-                xc.unshift(a);
+                xc = [a].concat(xc);
                 ++ye;
             }
 

--- a/bignumber.js
+++ b/bignumber.js
@@ -635,7 +635,7 @@
                 } else {
 
                     // Remove leading elements which are zero and adjust exponent accordingly.
-                    for ( e = -1 ; c[0] === 0; c.shift(), e -= LOG_BASE);
+                    for ( e = -1 ; c[0] === 0; c.splice(0, 1), e -= LOG_BASE);
 
                     // Count the digits of the first element of c to determine leading zeros, and...
                     for ( i = 1, v = c[0]; v >= 10; v /= 10, i++);
@@ -800,7 +800,7 @@
                 }
 
                 // Remove leading zeros.
-                for ( ; !a[0] && a.length > 1; a.shift() );
+                for ( ; !a[0] && a.length > 1; a.splice(0, 1) );
             }
 
             // x: dividend, y: divisor.
@@ -981,7 +981,7 @@
                     more = rem[0] != null;
 
                     // Leading zero?
-                    if ( !qc[0] ) qc.shift();
+                    if ( !qc[0] ) qc.splice(0, 1);
                 }
 
                 if ( base == BASE ) {
@@ -1691,7 +1691,7 @@
             }
 
             // Remove leading zeros and adjust exponent accordingly.
-            for ( ; xc[0] == 0; xc.shift(), --ye );
+            for ( ; xc[0] == 0; xc.splice(0, 1), --ye );
 
             // Zero?
             if ( !xc[0] ) {
@@ -2148,7 +2148,7 @@
             if (c) {
                 ++e;
             } else {
-                zc.shift();
+                zc.splice(0, 1);
             }
 
             return normalise( y, zc, e );


### PR DESCRIPTION
As we know from https://bugs.webkit.org/show_bug.cgi?id=170264
After performing a shift operation on an array with large numbers, appending new values via bracket notation fails.

It seems to be in limbo when and if this is going to be resolved soon by Apple. 

As we know this greatly affects bignumber.js in current iOS and Safari browsers.

Most notably affected is the infinite loop in the division function, https://github.com/MikeMcl/bignumber.js/issues/120.

Reading your comment https://github.com/MikeMcl/bignumber.js/issues/120#issuecomment-295379090
I see you were concerned about hidden number accuracy problems due to shift and bracket notation being used elsewhere. 

## Proposed Solution 

As a temporary workaround to help libraries downstream, could we mimic the `shift` operation with splice everywhere in this library?

This would ensure we don't encounter any unexpected results due to the webkit bug.

Splice seems to behave normally in buggy webkit and produces the same result as a shift. 
```javascript 
var arr = [0, 2147483648]; 
arr.splice(0, 1);
arr[1] = 1;

// This will evaluate true in Safari and is expected
expect(arr).toEqual([2147483648, 1])
```

The test suites seem to pass ok locally 👍 
Let's see what happens on CI 😄 

## Update

While the changes fixed the infinite loop, I noticed the browser test files when run locally on Safari failed.

This indicated other areas of this library had been affected and compromised by the WebKit bug. 

I isolated this to the `unshift()` method. Substituting this for a slower alternative of `Array.prototype.concat` resulted in all 80335 tests passing. 

> IN TOTAL: 80335 of 80335 tests passed in 3.096 secs.