### PR TITLE
Removed invalid h1 style definition

### DIFF
--- a/doc/API.html
+++ b/doc/API.html
@@ -17,7 +17,6 @@ p{margin:0 0 1em;width:600px}
 pre,ul{margin:1em 0}
 h1,h2,h3,h4,h5{margin:0;padding:1.5em 0 0}
 h1,h2{padding:.75em 0}
-!h1{font:400 3em Consolas,monaco,monospace;color:#000;margin-bottom:1em}
 h1{font:400 3em Verdana,sans-serif;color:#000;margin-bottom:1em}
 h2{font-size:2.25em;color:#ff2a00}
 h3{font-size:1.75em;color:#4dc71f}


### PR DESCRIPTION
"!h1{font:400 3em Consolas,monaco,monospace;color:#000;margin-bottom:1em}"
Using "!" in css is not allowed.