### PR TITLE
Fixed isBigNumber missing from type definition

### DIFF
--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -722,6 +722,11 @@ export class BigNumber {
     gte(n: number | string | BigNumber, base?: number): boolean;
 
     /**
+     * Always true, identifies BigNumber instances.
+     */
+    isBigNumber: true;
+
+    /**
      * Returns true if the value of this BigNumber is a finite number, otherwise returns false. The only possible
      * non-finite values of a BigNumber are `NaN`, `Infinity` and `-Infinity`.
      *


### PR DESCRIPTION
`BigNumber.prototype.isBigNumber` appears to be the recommended way to identify BigNumber instances, but was missing from the Typescript definition.