### PR TITLE
FIXED: compatibility to frozen Object.prototype

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -1477,6 +1477,12 @@
 
         // PROTOTYPE/INSTANCE METHODS
 
+        // Compatibility for frozen Object.prototype
+        Object.defineProperties( P, {
+            'toString' : { writable: true },
+            'valueOf' : { writable: true },
+        } );
+
 
         /*
          * Return a new BigNumber whose value is the absolute value of this BigNumber.

--- a/bignumber.mjs
+++ b/bignumber.mjs
@@ -1474,6 +1474,12 @@ function clone(configObject) {
 
     // PROTOTYPE/INSTANCE METHODS
 
+    // Compatibility for frozen Object.prototype
+    Object.defineProperties( P, {
+        'toString' : { writable: true },
+        'valueOf' : { writable: true },
+    } );
+
 
     /*
      * Return a new BigNumber whose value is the absolute value of this BigNumber.

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,7 @@
+ 
+// Make sure all tests pass in with frozen global prototype
+Object.freeze( Object.prototype );
+
 var time = process.hrtime(),
   passed = 0,
   total = 0;


### PR DESCRIPTION
If `Object.prototype` is frozen for security reasons before BigNumber.js is executed then the following error appear:
```
/mnt/lab/futoin-core/bignumber.js/bignumber.js:2518
        P.toString = function (b) {
                   ^

TypeError: Cannot assign to read only property 'toString' of object '#<BigNumber>'
    at clone (/mnt/lab/futoin-core/bignumber.js/bignumber.js:2518:20)
    at /mnt/lab/futoin-core/bignumber.js/bignumber.js:2705:17
    at Object.<anonymous> (/mnt/lab/futoin-core/bignumber.js/bignumber.js:2725:3)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
```

More info for justification: https://www.reddit.com/r/node/comments/7y341t/quick_cve20183721_proto_from_jsonparse_mitigation/

Note: minified versions are not rebuilt to avoid merge conflicts.