### PR TITLE
Provide constants for ZERO and ONE

### DIFF
--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -1738,6 +1738,16 @@ export declare class BigNumber {
    * See `MODULO_MODE`.
    */
   static readonly EUCLID: 9;
+
+  /**
+   * The number 0 (zero).
+   */
+  static readonly ZERO: BigNumber;
+
+  /**
+   * The number 1 (one).
+   */
+  static readonly ONE: BigNumber;
 }
 
 

--- a/bignumber.js
+++ b/bignumber.js
@@ -377,6 +377,8 @@
         BigNumber.ROUND_HALF_FLOOR = 8;
         BigNumber.EUCLID = 9;
 
+        BigNumber.ZERO = new BigNumber(0);
+        BigNumber.ONE = new BigNumber(1);
 
         /*
          * Configure infrequently-changing library-wide settings.

--- a/bignumber.mjs
+++ b/bignumber.mjs
@@ -374,6 +374,8 @@ function clone(configObject) {
     BigNumber.ROUND_HALF_FLOOR = 8;
     BigNumber.EUCLID = 9;
 
+    BigNumber.ZERO = new BigNumber(0);
+    BigNumber.ONE = new BigNumber(1);
 
     /*
      * Configure infrequently-changing library-wide settings.

--- a/doc/API.html
+++ b/doc/API.html
@@ -99,6 +99,8 @@ li span{float:right;margin-right:10px;color:#c0c0c0}
       <li><a href="#round-half-even" >ROUND_HALF_EVEN</a></li>
       <li><a href="#round-half-ceil" >ROUND_HALF_CEIL</a></li>
       <li><a href="#round-half-floor">ROUND_HALF_FLOOR</a></li>
+      <li><a href="#constant-zero">ZERO</a></li>
+      <li><a href="#constant-one">ONE</a></li>
     </ul>
 
     <b> INSTANCE </b>
@@ -840,6 +842,28 @@ BigNumber.random(20)            // '0.78193327636914089009'</pre>
 BigNumber.config({ ROUNDING_MODE: BigNumber.ROUND_CEIL })
 BigNumber.config({ ROUNDING_MODE: 2 })     // equivalent</pre>
 
+    <p>
+      Furthermore, the constructor provides some commonly used BigNumber constants as properties:
+    </p>
+    <table>
+      <tr>
+        <th>Property</th>
+        <th>Value</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td id="constant-zero"><b>ZERO</b></td>
+        <td class='centre'>0</td>
+        <td>The number zero.</td>
+      </tr>
+      <tr>
+        <td id="constant-one"><b>ONE</b></td>
+        <td class='centre'>1</td>
+        <td>The number one.</td>
+      </tr>
+    </table>
+    <pre>BigNumber.ZERO.plus(15)         // '15'
+BigNumber.ONE.times(15)         // '15'</pre>
 
     <h3>INSTANCE</h3>
 

--- a/test/methods/BigNumber.js
+++ b/test/methods/BigNumber.js
@@ -580,4 +580,8 @@ Test('bigNumber', function () {
     // TODO: more ALPHABET tests.
 
     BigNumber.config({ALPHABET: '0123456789abcdefghijklmnopqrstuvwxyz'});
+
+    // Test constants
+    t('0', BigNumber.ZERO);
+    t('1', BigNumber.ONE);
 });


### PR DESCRIPTION
This pull request introduces two BigNumber constants as properties of the constructor: The number zero and the number one. These constants are particularly useful as initial values for computations (like calculating a sum or a product) and as default parameter values in functions. Providing them as constants makes the respective code more readable and efficient than the repeated invocation of the constructor.

### Sample use cases

As default parameter values:
```javascript
function getValue(defaultValue = BigNumber.ZERO) {
    ...
}
```
As initial value for computations:
```javascript
let sum = BigNumber.ZERO;
while (...) {
    ...
    sum = sum.plus(...);
}
```
Similar use cases can be constructed for `BigNumber.ONE`.