### PR TITLE
make isBigNumber a type guard in bignumber.d.ts

### DIFF
--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -1565,7 +1565,7 @@ export declare class BigNumber {
    *
    * @param value The value to test.
    */
-  static isBigNumber(value: any): boolean;
+  static isBigNumber(value: any): value is BigNumber;
 
   /**
    *


### PR DESCRIPTION
This allows for TypeScript code like this:
```typescript
if (BigNumber.isBigNumber(value)) {
  console.log(value.toString())
}
```
instead of
```typescript
if (BigNumber.isBigNumber(value)) {
  console.log((<BigNumber>value).toString())
}
```
https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards