### PR TITLE
Fixed toFraction() call signature in bignumber.d.ts

### DIFF
--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -1373,7 +1373,7 @@ export declare class BigNumber {
    *
    * @param [max_denominator] The maximum denominator, integer > 0, or Infinity.
    */
-  toFraction(max_denominator?: BigNumber.Value): BigNumber[];
+  toFraction(max_denominator?: BigNumber.Value): string[];
 
   /**
    * As `valueOf`.


### PR DESCRIPTION
Typescript typechecker couldn't detect that you were actually using BigNumber's methods on plain strings. Running the compiled code would throw a TypeError exception.

Prior to this simple fix the following Typescript snippet would lead to an exception at runtime:

```Typescript
let fraction: BigNumber[] = new BigNumber(1/2).toFraction();
let numerator: BigNumber = fraction[0].times(1000);
```

```Error
var numerator = fraction[0].times(1000);
                            ^

TypeError: fraction[0].times is not a function
    at Object.<anonymous> (...\dist\test.js:10:29)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
```

This commit fixes the issue.