### PR TITLE
Allow creating BigNumber with {s, e, c} 

### DIFF
--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -109,7 +109,7 @@ export namespace BigNumber {
      * Calling `toString` with a base argument, e.g. `toString(10)`, will also always return normal
      * notation.
      */
-    EXPONENTIAL_AT?: number|[number, number];
+    EXPONENTIAL_AT?: number | [number, number];
 
     /**
      * An integer, magnitude 1 to 1e+9, or an array, [-1e+9 to -1, 1 to 1e+9].
@@ -144,7 +144,7 @@ export namespace BigNumber {
      * The largest possible magnitude of a finite BigNumber is 9.999...e+1000000000.
      * The smallest possible magnitude of a non-zero BigNumber is 1e-1000000000.
      */
-    RANGE?: number|[number, number];
+    RANGE?: number | [number, number];
 
     /**
      * A boolean: `true` or `false`. Default value: `false`.
@@ -330,10 +330,28 @@ export namespace BigNumber {
     suffix?: string;
   }
 
+  export interface BigNumberData {
+    /**
+     * The coefficient of the value of this BigNumber, an array of base 1e14 integer numbers.
+     */
+    readonly c: number[];
+
+    /**
+     * The exponent of the value of this BigNumber, an integer number, -1000000000 to 1000000000.
+     */
+    readonly e: number;
+
+    /**
+     * The sign of the value of this BigNumber, -1 or 1.
+     */
+    readonly s: number;
+
+    [key: string]: any;
+  }
   export type Instance = BigNumber;
   export type ModuloMode = 0 | 1 | 3 | 6 | 9;
   export type RoundingMode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-  export type Value = string | number | BigNumber;
+  export type Value = string | number | BigNumber | BigNumberData;
 }
 
 export declare class BigNumber {
@@ -1057,7 +1075,7 @@ export declare class BigNumber {
    * @param n A numeric value.
    * @param [base] The base of n.
    */
-  multipliedBy(n: BigNumber.Value, base?: number) : BigNumber;
+  multipliedBy(n: BigNumber.Value, base?: number): BigNumber;
 
   /**
    * Returns a BigNumber whose value is the value of this BigNumber multiplied by `n`.

--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -330,7 +330,7 @@ export namespace BigNumber {
     suffix?: string;
   }
 
-  export interface BigNumberData {
+  export interface Object {
     /**
      * The coefficient of the value of this BigNumber, an array of base 1e14 integer numbers.
      */
@@ -351,7 +351,7 @@ export namespace BigNumber {
   export type Instance = BigNumber;
   export type ModuloMode = 0 | 1 | 3 | 6 | 9;
   export type RoundingMode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-  export type Value = string | number | BigNumber | BigNumberData;
+  export type Value = string | number | BigNumber | BigNumber.Object;
 }
 
 export declare class BigNumber {

--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -330,7 +330,7 @@ export namespace BigNumber {
     suffix?: string;
   }
 
-  export interface Object {
+  interface RegularNumberObject {
     /**
      * The coefficient of the value of this BigNumber, an array of base 1e14 integer numbers.
      */
@@ -346,8 +346,9 @@ export namespace BigNumber {
      */
     readonly s: number;
 
-    [key: string]: any;
   }
+  type NaNObject = { readonly c: null, readonly e: null, readonly s: null };
+  export type Object = RegularNumberObject | NaNObject;
   export type Instance = BigNumber;
   export type ModuloMode = 0 | 1 | 3 | 6 | 9;
   export type RoundingMode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;

--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -345,8 +345,8 @@ export namespace BigNumber {
      * The sign of the value of this BigNumber, -1 or 1.
      */
     readonly s: number;
-
   }
+
   type NaNObject = { readonly c: null, readonly e: null, readonly s: null };
   export type Object = RegularNumberObject | NaNObject;
   export type Instance = BigNumber;

--- a/bignumber.js
+++ b/bignumber.js
@@ -195,7 +195,8 @@
       if (b == null) {
 
         // Duplicate.
-        if (n instanceof BigNumber) {
+        if (n instanceof BigNumber 
+          || (n != null && n.s != null && n.e != null && n.c != null)) {
           x.s = n.s;
           x.e = n.e;
           x.c = (n = n.c) ? n.slice() : n;

--- a/bignumber.js
+++ b/bignumber.js
@@ -196,7 +196,7 @@
 
         // Duplicate.
         if (n instanceof BigNumber 
-          || (n != null && n.s != null && n.e != null && n.c != null)) {
+          || (n && typeof n.s !== 'undefined' && typeof n.e !== 'undefined' && typeof n.c !== 'undefined')) {
           x.s = n.s;
           x.e = n.e;
           x.c = (n = n.c) ? n.slice() : n;

--- a/doc/API.html
+++ b/doc/API.html
@@ -185,7 +185,7 @@ li span{float:right;margin-right:10px;color:#c0c0c0}
       BigNumber<code class='inset'>BigNumber(n [, base]) <i>&rArr; BigNumber</i></code>
     </h5>
     <p>
-      <code>n</code>: <i>number|string|BigNumber</i><br />
+      <code>n</code>: <i>number|string|BigNumber|BigNumberData</i><br />
       <code>base</code>: <i>number</i>: integer, <code>2</code> to <code>36</code> inclusive. (See
       <a href='#alphabet'><code>ALPHABET</code></a> to extend this range).
     </p>
@@ -268,6 +268,10 @@ BigNumber.DEBUG = true
 new BigNumber(823456789123456.3)
 // '[BigNumber Error] Not a base 2 number'
 new BigNumber(9, 2)</pre>
+    <p>
+      As a way to interact with other modules that are using BigNumber you can use BigNumberData directly
+    </p>
+    <pre>new BigNumber({ s: 1, e: 2, c: [ 777, 12300000000000 ] })    // '777.123'</pre>
 
 
 

--- a/test/methods/BigNumber.js
+++ b/test/methods/BigNumber.js
@@ -199,6 +199,9 @@ Test('bigNumber', function () {
     t('-102', new BigNumber('-0o146').toString());
     t('0.5', new BigNumber('0o0.4').toString());
 
+    t('100002222.2222333322', new BigNumber({ s: 1, e: 8, c: [100002222, 22223333220000] }).toString())
+    t('7777777777.123123123', new BigNumber({ s: 1, e: 9, c: [7777777777, 12312312300000] }).toString())
+
     // Base-conversion tests
 
     //var alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_';

--- a/test/methods/BigNumber.js
+++ b/test/methods/BigNumber.js
@@ -201,6 +201,7 @@ Test('bigNumber', function () {
 
     t('100002222.2222333322', new BigNumber({ s: 1, e: 8, c: [100002222, 22223333220000] }).toString())
     t('7777777777.123123123', new BigNumber({ s: 1, e: 9, c: [7777777777, 12312312300000] }).toString())
+    t('NaN', new BigNumber({ s: null, e: null, c: null }).toString())
 
     // Base-conversion tests
 


### PR DESCRIPTION
Hi,

`BigNumber` is not yet stable (and might change forever), but I think we can define `BigNumberData` which is pretty stable:

```typescript
  export interface BigNumberData {
    /**
     * The coefficient of the value of this BigNumber, an array of base 1e14 integer numbers.
     */
    readonly c: number[];

     /**
     * The exponent of the value of this BigNumber, an integer number, -1000000000 to 1000000000.
     */
    readonly e: number;

     /**
     * The sign of the value of this BigNumber, -1 or 1.
     */
    readonly s: number;
  }
```

That will actually allow multiple packages to have different BigNumber versions, but still interact *safely* without converting to string. Nice thing about this way is that if you have `BigNumber7` & `BigNumber8`, 
```javascript
new BigNumber8(new BigNumber7('123'))
new BigNumber7(new BigNumber8('123'))
```
just works (presumably safely, even with breaking changes in BigNumber v8 that didn't change BigNumberData).


Maybe we can also version this `BigNumberData` if you believe it will change in the future.
I didn't do it in this PR , but for example:
```typescript
  export interface BigNumberData {
    /**
     * The coefficient of the value of this BigNumber, an array of base 1e14 integer numbers.
     */
    readonly c: number[];

     /**
     * The exponent of the value of this BigNumber, an integer number, -1000000000 to 1000000000.
     */
    readonly e: number;

     /**
     * The sign of the value of this BigNumber, -1 or 1.
     */
    readonly s: number;
     /**
     * The version of this BigNumber representation 
     */
    readonly ver: number
  }
```

and once ver is changed BigNumber will throw when trying to construct with unknown versions