### PR TITLE
Corrected docs using method that doesn't exist

### DIFF
--- a/doc/API.html
+++ b/doc/API.html
@@ -1279,7 +1279,7 @@ y.isPositive()                  // true</pre>
     </p>
     <pre>
 x = new BigNumber(-0)
-x.isZero() && x.isneg()         // true
+x.isZero() && x.isNegative()         // true
 y = new BigNumber(Infinity)
 y.isZero()                      // false</pre>
     <p>Note: <code>n == 0</code> can be used if <code>n &gt;= Number.MIN_VALUE</code>.</p>


### PR DESCRIPTION
The documentation uses ".isneg" in an example however this doesn't seem to be a method (not in documentation and throws a "is not a function" error). I have corrected this to ".isNegative()"