### PR TITLE
BigNumber.parseJSON

### DIFF
--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -1742,6 +1742,22 @@ export declare class BigNumber implements BigNumber.Instance {
   static min(...n: BigNumber.Value[]): BigNumber;
 
   /**
+   * Returns parsed JSON with all numbers in the result replaced by BigNumber instances.
+   *
+   * JSON has arbitrary precision numbers, which can lose precision when parsed with JSON.parse
+   * This returns parsed JSON with numbers always exact and unrounded.
+   *
+   * ```ts
+   * BigNumber.parseJSON( '7290.9817309441811021231245' )      // '7290.9817309441811021231245'
+   * BigNumber.parseJSON( '{"x":0.492984168922526525206}' ).x  // '0.492984168922526525206'
+   * BigNumber.parseJSON( '[10,41432809811874693461783]' )     // ['10','41432809811874693461783']
+   * ```
+   *
+   * @param json
+   */
+  static parseJSON(json: string): any;
+
+  /**
    * Returns a new BigNumber with a pseudo-random value equal to or greater than 0 and less than 1.
    *
    * The return value will have `decimalPlaces` decimal places, or less if trailing zeros are

--- a/bignumber.js
+++ b/bignumber.js
@@ -24,9 +24,9 @@
  *      isInteger                       |  isBigNumber
  *      isLessThan               lt     |  maximum              max
  *      isLessThanOrEqualTo      lte    |  minimum              min
- *      isNaN                           |  random
- *      isNegative                      |  sum
- *      isPositive                      |
+ *      isNaN                           |  parseJSON
+ *      isNegative                      |  random
+ *      isPositive                      |  sum
  *      isZero                          |
  *      minus                           |
  *      modulo                   mod    |
@@ -648,6 +648,25 @@
      */
     BigNumber.minimum = BigNumber.min = function () {
       return maxOrMin(arguments, P.gt);
+    };
+
+
+    /*
+     * Parse a JSON string, but replace each number in the result with a BigNumber
+     *
+     * arguments {string}
+     */
+    BigNumber.parseJSON = function (str) {
+      if ( ! JSON || ! JSON.parse )
+        throw Error( 'Requires JSON.parse' );
+
+      var prefix = '^ba38f1629191d^BigNumber.parseJSON^';
+      var pre_decode = str.replace(/((?:[^"]*?(?:"(?:[^"\\]|\\.)*?")?)*?)((?:[:,\[]|^)[\s\n]*)(-?(0|([1-9]\d*))(\.\d+)?([eE][-+]?\d*)?)/gsy, '$1$2"' + prefix + '$3"');
+      return JSON.parse(pre_decode, function (key, value) {
+        if (typeof value !== 'string' || value.indexOf(prefix) !== 0)
+          return value;
+        return new BigNumber(value.substr(prefix.length));
+      });
     };
 
 

--- a/test/methods/parseJSON.js
+++ b/test/methods/parseJSON.js
@@ -1,0 +1,28 @@
+if (typeof Test === 'undefined') require('../tester');
+
+Test('parseJSON', function () {
+
+    function t(expected, value){
+        Test.isTrue(expected.eq(value));
+    }
+
+    t(new BigNumber(10 ), BigNumber.parseJSON('1e1'));
+    t(new BigNumber('7290.9817309441811021231245'), BigNumber.parseJSON('7290.9817309441811021231245') );
+    t(new BigNumber('0.492984168922526525206'), BigNumber.parseJSON('{"x":0.492984168922526525206}').x );
+    t(new BigNumber('41432809811874693461783'), BigNumber.parseJSON('[10,41432809811874693461783]')[1] );
+
+    var result = BigNumber.parseJSON(JSON.stringify({
+      foo: { 
+        bar: [50,51,52,[ {x:1e-999} ] ],
+      },
+      "bar\"": 2e-999,
+      "\\": { y: 3e-999 },
+      "\\\"\\": [4e-999],
+    }));
+
+    t(new BigNumber(1e-999), result.foo.bar[3][0].x);
+    t(new BigNumber(2e-999), result['bar"']);
+    t(new BigNumber(3e-999), result['\\'].y);
+    t(new BigNumber(4e-999), result['\\"\\'][0]);
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ console.log('\n Testing bignumber.js\n');
   'multipliedBy',
   'negated',
   'isMethods',
+  'parseJSON',
   'plus',
   'precision',
   'random',


### PR DESCRIPTION
This adds a BigNumber.parseJSON method that supports arbitrary precision within JSON, by replacing all numbers in the result with BigNumbers. JSON has arbitrary precision, but JSON.parse converts all JSON numbers to JavaScript numbers which causes a loss of precision.

```
JSON.parse( '1e-999' ) === 0;
// vs.
BigNumber.parseJSON( '1e-999' ).eq( new BigNumber( '1e-999' ) )
```

This provides a method for parsing JSON without risk of losing number precision. It requires JSON.parse to be available, which is ES5; but is also available as a global object in ES3 via https://github.com/douglascrockford/JSON-js/blob/master/json2.js ; so anyone using this library that requires ES3 compatibility would also need to include json2.js as a dependency.