### PR TITLE
Fix ALPHABET regex to allow comma and reject empty string

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -543,7 +543,7 @@
 
             // Disallow if only one character,
             // or if it contains '+', '-', '.', whitespace, or a repeated character.
-            if (typeof v == 'string' && !/^.$|[+-.\s]|(.).*\1/.test(v)) {
+            if (typeof v == 'string' && !/^.$|[+\-.\s]|(.).*\1/.test(v)) {
               ALPHABET = v;
             } else {
               throw Error

--- a/bignumber.js
+++ b/bignumber.js
@@ -543,7 +543,7 @@
 
             // Disallow if only one character,
             // or if it contains '+', '-', '.', whitespace, or a repeated character.
-            if (typeof v == 'string' && !/^.$|[+\-.\s]|(.).*\1/.test(v)) {
+            if (typeof v == 'string' && !/^.?$|[+\-.\s]|(.).*\1/.test(v)) {
               ALPHABET = v;
             } else {
               throw Error

--- a/bignumber.js
+++ b/bignumber.js
@@ -541,7 +541,7 @@
           if (obj.hasOwnProperty(p = 'ALPHABET')) {
             v = obj[p];
 
-            // Disallow if only one character,
+            // Disallow if less than two characters,
             // or if it contains '+', '-', '.', whitespace, or a repeated character.
             if (typeof v == 'string' && !/^.?$|[+\-.\s]|(.).*\1/.test(v)) {
               ALPHABET = v;

--- a/test/methods/config.js
+++ b/test/methods/config.js
@@ -226,6 +226,9 @@ Test('config', function () {
     tx(function () {BigNumber.config({ALPHABET: ',.'})}, "ALPHABET: ',.'");
     tx(function () {BigNumber.config({ALPHABET: '0123456789.'})}, "ALPHABET: '0123456789.'");
 
+    BigNumber.config({ALPHABET: '0,'});
+    t('0,', BigNumber.config().ALPHABET);
+
     BigNumber.config({ALPHABET: 'xy'});
     t('xy', BigNumber.config().ALPHABET);
 

--- a/test/methods/config.js
+++ b/test/methods/config.js
@@ -223,7 +223,9 @@ Test('config', function () {
     tx(function () {BigNumber.config({ALPHABET: 2})}, "ALPHABET: 2");
     tx(function () {BigNumber.config({ALPHABET: true})}, "ALPHABET: true");
     tx(function () {BigNumber.config({ALPHABET: 'aba'})}, "ALPHABET: 'aba'");
-    tx(function () {BigNumber.config({ALPHABET: ',.'})}, "ALPHABET: ',.'");
+    tx(function () {BigNumber.config({ALPHABET: '0.'})}, "ALPHABET: '0.'");
+    tx(function () {BigNumber.config({ALPHABET: '0-'})}, "ALPHABET: '0-'");
+    tx(function () {BigNumber.config({ALPHABET: '0+'})}, "ALPHABET: '0+'");
     tx(function () {BigNumber.config({ALPHABET: '0123456789.'})}, "ALPHABET: '0123456789.'");
 
     BigNumber.config({ALPHABET: '0,'});

--- a/test/methods/config.js
+++ b/test/methods/config.js
@@ -219,6 +219,7 @@ Test('config', function () {
 
     BigNumber.config({ALPHABET: '0123456789abcdefghijklmnopqrstuvwxyz'});
 
+    tx(function () {BigNumber.config({ALPHABET: ''})}, "ALPHABET: ''");
     tx(function () {BigNumber.config({ALPHABET: '1'})}, "ALPHABET: '1'");
     tx(function () {BigNumber.config({ALPHABET: 2})}, "ALPHABET: 2");
     tx(function () {BigNumber.config({ALPHABET: true})}, "ALPHABET: true");


### PR DESCRIPTION
`ALPHABET` is supposed to accept [any characters except `+`, `-`, `.` and whitespace](https://github.com/MikeMcl/bignumber.js/blob/6d2427a6f694acb5d248b5e986d65f3eb08996d3/doc/API.html#L630-L632). It currently also refuses to accept `,`. The hyphen causes the regex `[+-.\s]` to be interpreted as a character range rather than a regular character set. This range is `+,-.`, which happens to contain hyphen, but also comma.