### PR TITLE
fix: Sum of zero elements equals zero

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -799,9 +799,9 @@
      * arguments {number|string|BigNumber}
      */
     BigNumber.sum = function () {
-      var i = 1,
+      var i = 0,
         args = arguments,
-        sum = new BigNumber(args[0]);
+        sum = new BigNumber(0);
       for (; i < args.length;) sum = sum.plus(args[i++]);
       return sum;
     };

--- a/test/methods/sum.js
+++ b/test/methods/sum.js
@@ -12,4 +12,5 @@ Test('sum', function () {
     t(expectedSum, BigNumber.sum(new BigNumber(100), new BigNumber(200), new BigNumber(300)));
     t(expectedSum, BigNumber.sum(100, '200', new BigNumber(300)));
     t(expectedSum, BigNumber.sum(99.9, 200.05, 300.05));
+    t(new BigNumber(0), BigNumber.sum());
 });


### PR DESCRIPTION
I believe sum of zero elements equals zero. Current implementation produces NaN for this case.