### PR TITLE
removed '$' symbol as it causes an error in the bash as shown below upon doing a copy paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import BigNumber from './path/to/bignumber.mjs';
 ### [Node.js](http://nodejs.org):
 
 ```bash
-$ npm install bignumber.js
+npm install bignumber.js
 ```
 
 ```javascript


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43913734/122663199-4e217280-d1b6-11eb-8143-b607adf98f6d.png)

The above error can be removed by deleting the '$' symbol from the documentation to successfully execute `'npm install'`
