### PR TITLE
Fix #251

### DIFF
--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -1827,3 +1827,5 @@ export declare class BigNumber implements BigNumber.Instance {
    */
   static set(object: BigNumber.Config): BigNumber.Config;
 }
+
+export function BigNumber(n: BigNumber.Value, base?: number): BigNumber;


### PR DESCRIPTION
Add TypeScript binding to allow instantiating `BigNumber` without the `new` keyword

I opted against adding jsdoc to this binding, only because there was no way to link directly to the constructor itself.