### PR TITLE
Store alphabet internally as object (fixes #309 and #250)

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -2873,9 +2873,6 @@
       c = alphabet.charAt(i);
       for (j = 0; j < i; j++) {
         d = alphabet.charAt(j);
-        if (c === d) {
-          throw new Error(bignumberError + 'Duplicate character in alphabet: ' + c);
-        }
         if (c.toLowerCase() === d.toLowerCase()) {
           caseSensitive = true;
         }

--- a/test/methods/BigNumber.js
+++ b/test/methods/BigNumber.js
@@ -622,10 +622,10 @@ Test('bigNumber', function () {
     BigNumber.config({ALPHABET: 'xy'});
 
     t('1', 'y', 2);    // 1
-    t('2', 'yx', 2);   // 10
-    t('3', 'yy', 2);   // 11
-    t('4', 'yxx', 2);  // 100
-    t('5', 'yxy', 2);  // 101
+    t('2', 'Yx', 2);   // 10
+    t('3', 'yY', 2);   // 11
+    t('4', 'YxX', 2);  // 100
+    t('5', 'yXy', 2);  // 101
 
     BigNumber.config({ALPHABET: '0123456789*#'});
 


### PR DESCRIPTION
This change does not modify the external contract of the library.

This change replaces the internal ALPHABET string with an object of the form:

```ts
{
  // the original alphabet
  original: '0123456789abcdef',
  length: 16,

  // whether this alphabet is compatible with decimal (starts with '0123456789')
  decimalCompatible: true,

  // delegates directly to original.charAt
  charAt(i) { ... },

  // case-insensitive version of indexOf, that takes in the base as an optional param
  charIndex(c, b) { ... }
}
```

I've tested this locally and everything seems to function as I expect. I also modified the existing unit tests for the BigNumber constructor to use mixed-case strings.