### PR TITLE
fix: allow object literals without _isBignumber flag

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -188,7 +188,7 @@
 
       if (b == null) {
 
-        if (v && v._isBigNumber === true) {
+        if (v && typeof v.c !== "undefined" && typeof v.s !== "undefined" && typeof v.e !== "undefined") {
           x.s = v.s;
 
           if (!v.c || v.e > MAX_EXP) {

--- a/bignumber.mjs
+++ b/bignumber.mjs
@@ -185,7 +185,7 @@ function clone(configObject) {
 
     if (b == null) {
 
-      if (v && v._isBigNumber === true) {
+      if (v && typeof v.c !== "undefined" && typeof v.s !== "undefined" && typeof v.e !== "undefined") {
         x.s = v.s;
 
         if (!v.c || v.e > MAX_EXP) {


### PR DESCRIPTION
Fixes Rehydration after structural cloning #317.

An obj `{ s: 1, e: -2, c: [ 50 ] } ` is not a BigNumber, hence `BigNumber.isBigNumber(obj)` is false, but you can construct a BigNumber from it: `new BigNumber(obj)`.

This simplifies serialization/deserialization, since BigNumber values can be sent over the wire/inter process communication.

```ts
const someFn = (valueThatMightBeSerializedOrNot: BigNumber) => new BigNumber(valueThatMightBeSerializedOrNot).plus(1);
const bnValue = new BigNumber(1);
const fromJsonValue = JSON.parse(JSON.stringify(bnValue);

assert.strictEqual(someFn(bnValue).toString(), someFn(fromJsonValue).toString())
```
