### PR TITLE
Add exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,15 @@
   "module": "bignumber.mjs",
   "browser": "bignumber.js",
   "types": "bignumber.d.ts",
+  "exports": {
+    ".": {
+      "require": "./bignumber.js",
+      "import": "./bignumber.mjs",
+      "browser": "./bignumber.js",
+      "types": "./bignumber.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "author": {
     "name": "Michael Mclaughlin",
     "email": "M8ch88l@gmail.com"

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "types": "bignumber.d.ts",
   "exports": {
     ".": {
+      "types": "./bignumber.d.ts",
       "require": "./bignumber.js",
       "import": "./bignumber.mjs",
-      "browser": "./bignumber.js",
-      "types": "./bignumber.d.ts"
+      "browser": "./bignumber.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This solves https://github.com/rollup/plugins/issues/1130
Bundling `json-bigint` with `rollup` fails without this change.