### PR TITLE
Fix import types

### DIFF
--- a/bignumber.d.mts
+++ b/bignumber.d.mts
@@ -31,7 +31,7 @@
 //
 // The use of compiler option `--strictNullChecks` is recommended.
 
-export = BigNumber;
+export default BigNumber;
 
 export namespace BigNumber {
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,18 @@
   "types": "bignumber.d.ts",
   "exports": {
     ".": {
-      "types": "./bignumber.d.ts",
-      "require": "./bignumber.js",
-      "import": "./bignumber.mjs",
-      "browser": "./bignumber.js"
+      "import": {
+        "types": "./bignumber.d.mts",
+        "default": "./bignumber.mjs"
+      },
+      "require": {
+        "types": "./bignumber.d.ts",
+        "default": "./bignumber.js"
+      },
+      "browser": {
+        "types": "./bignumber.d.ts",
+        "default": "./bignumber.js"
+      }
     },
     "./bignumber.mjs": "./bignumber.mjs",
     "./bignumber.js": "./bignumber.js",


### PR DESCRIPTION
https://arethetypeswrong.github.io/?p=bignumber.js%409.1.2

Fix imports and types by copying `bignumber.d.ts` to `bignumber.d.mts`.

Test with: `npx @arethetypeswrong/cli@latest --pack .`