### PR TITLE
Align types with implementation

### DIFF
--- a/bignumber.d.ts
+++ b/bignumber.d.ts
@@ -324,7 +324,7 @@ export namespace BigNumber {
   type Constructor = typeof BigNumber;
   type ModuloMode = 0 | 1 | 3 | 6 | 9;
   type RoundingMode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-  type Value = string | number | Instance;
+  type Value = string | number | null | undefined | Instance;
 }
 
 export declare class BigNumber implements BigNumber.Instance {

--- a/test/methods/BigNumber.js
+++ b/test/methods/BigNumber.js
@@ -19,6 +19,8 @@ Test('bigNumber', function () {
     });
 
     // Parsing tests
+    Test.areEqual(new BigNumber(null).isNaN(), true)
+    Test.areEqual(new BigNumber(undefined).isNaN(), true)
 
     t('Infinity', new BigNumber('1e10000000000'));
     t('-Infinity', new BigNumber('-1e10000000000'));


### PR DESCRIPTION
Checking implementation behaviour in browser gives us following results:

<img width="269" alt="Screenshot 2024-08-08 at 23 25 13" src="https://github.com/user-attachments/assets/375fd49d-77f6-4ce6-9e6e-a6684449a824">


It means we are safe to pass null or undefined to BigNumber constructor. 

Unfortunately types are not aligned with implementation.  

Main intention of that MR is to fix types.