### PR TITLE
Fix toFormat duplicating the fraction when groupSize is 0

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -2779,6 +2779,8 @@ function clone(configObject) {
           str += groupSeparator + intPart.substr(i, g1);
         }
         if (g2 > 0) str += groupSeparator + intPart.slice(i);
+      } else {
+        str = intPart;
       }
 
       if (fractionPart) {

--- a/test/methods/toFormat.js
+++ b/test/methods/toFormat.js
@@ -291,6 +291,26 @@ Test('toFormat', function () {
     t('123,456,789.123456789', '123456789.123456789', null);
     t('123,456,789.123456789', '123456789.123456789', undefined);
 
+    // groupSize: 0 disables grouping; the fraction must not be duplicated. #407
+
+    BigNumber.config({ FORMAT: {
+        decimalSeparator: '.',
+        groupSeparator: '',
+        groupSize: 0
+    }});
+
+    t('100000.12', '100000.12');
+    t('1234.56', '1234.56');
+    t('-9.91', '-9.91');
+
+    // Restore default FORMAT for any tests that follow.
+
+    BigNumber.config({ FORMAT: {
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        groupSize: 3
+    }});
+
     //if (typeof window == 'undefined') {
     //    var vm = require('vm');
     //    t('1,234.57', '1234.567', vm.runInNewContext('[2, 2]'));


### PR DESCRIPTION
Fixes #407.

When `groupSize` is `0`, `toFormat` returned a string with two decimal separators (e.g. `100000.00.00`). This works correctly in 9.3.1.

`str` starts as the full `toFixed()` output and is only reassigned to the integer part inside the `g1 > 0` grouping branch, which is skipped when `groupSize` is `0`. The fraction section then appends the decimal onto the full string. This resets `str` to the integer part when the branch is skipped, matching the 9.3.1 behaviour. No effect when `groupSize > 0`.

Added three cases to `test/methods/toFormat.js`. The full suite passes (65719/65719).

I kept this as the smallest possible change. The cleaner structural fix is probably to stop reusing `str` as an accumulator and assemble the result from independent integer and fraction parts, the way 9.3.1 did _(the last version I verified before jumping straight to 11; I didn't bisect which release in between introduced the regression)_ — that removes the shared-state hazard entirely rather than guarding it.