### PR TITLE
Fix toFraction returning a sub-optimal rational approximation

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -2812,7 +2812,7 @@ function clone(configObject) {
    * '[BigNumber Error] Argument {not an integer|out of range} : {md}'
    */
   P.toFraction = function (md) {
-    var d, d0, d1, d2, e, exp, n, n0, n1, q, r, s,
+    var d, d0, d1, d2, e, exp, n, n0, n1, q, r, s, xd, xn,
       x = this,
       xc = x.c;
 
@@ -2846,6 +2846,11 @@ function clone(configObject) {
     MAX_EXP = 1 / 0;
     n = new BigNumber(s);
 
+    // The exact value of abs(x) as the fraction xn / xd, where xd is a power of ten.
+    // Used below to determine which approximation is closer to x without loss of precision.
+    xn = n;
+    xd = d;
+
     // n0 = d1 = 0
     n0.c[0] = 0;
 
@@ -2864,12 +2869,16 @@ function clone(configObject) {
     d2 = div(md.minus(d0), d1, 0, 1);
     n0 = n0.plus(d2.times(n1));
     d0 = d0.plus(d2.times(d1));
-    n0.s = n1.s = x.s;
-    e = e * 2;
 
-    // Determine which fraction is closer to x, n0/d0 or n1/d1
-    r = div(n1, d1, e, ROUNDING_MODE).minus(x).abs().comparedTo(
-        div(n0, d0, e, ROUNDING_MODE).minus(x).abs()) < 1 ? [n1, d1] : [n0, d0];
+    // Determine which fraction is closer to abs(x), n1/d1 or n0/d0, by exact comparison
+    // of abs(n1/d1 - xn/xd) and abs(n0/d0 - xn/xd) using cross-multiplication. All of n1,
+    // d1, n0, d0, xn and xd are non-negative here, so no precision is lost.
+    //   abs(n1/d1 - xn/xd) <= abs(n0/d0 - xn/xd)
+    //   <=> abs(n1*xd - xn*d1) * d0 <= abs(n0*xd - xn*d0) * d1
+    r = n1.times(xd).minus(xn.times(d1)).abs().times(d0).comparedTo(
+        n0.times(xd).minus(xn.times(d0)).abs().times(d1)) < 1 ? [n1, d1] : [n0, d0];
+
+    r[0].s = x.s;
 
     MAX_EXP = exp;
 

--- a/test/methods/toFraction.js
+++ b/test/methods/toFraction.js
@@ -2940,6 +2940,19 @@ Test('toFraction', function () {
     t('1111,9',  '12.345e1', new BigNumber(10));
     t('2469,20', '12.345e1', new BigNumber('123e399'));
 
+    // The result must be the closest fraction with denominator <= maxDenominator.
+    // Expected values generated with Python's fractions module:
+    //   Fraction(value).limit_denominator(maxDenominator)
+    // Previously these returned a sub-optimal convergent (e.g. '24,7' for 3.43 with md 51)
+    // because the final closer-fraction comparison was rounded to too few decimal places.
+    t('175,51', '3.43', '51');                          // not 24,7   (24/7 ≈ 3.428571, 175/51 ≈ 3.431373)
+    t('-175,51', '-3.43', '51');                         // not -24,7
+    t('77,51', '1.51', '51');                            // not 74,49
+    t('-494534,587', '-842.477', '725');                 // not -347943,413
+    t('506662,523', '968.761', '597');                   // not 154033,159
+    t('-108109,254', '-425.6260', '297');                // not -52352,123
+    t('20090,523', '38.413', '524');                     // not 18323,477
+
     Test.isException(function () {new BigNumber('12.3e1').toFraction('')}, ".toFraction('')");
     Test.isException(function () {new BigNumber('12.3e1').toFraction(' ')}, ".toFraction(' ')");
     Test.isException(function () {new BigNumber('12.3e1').toFraction('\t')}, ".toFraction('\t')");


### PR DESCRIPTION
Fixes `toFraction(maxDenominator)` returning a fraction that is **not** the closest one with denominator ≤ `maxDenominator`.

## Minimal repro

```js
BigNumber.config({ DECIMAL_PLACES: 20, ROUNDING_MODE: 4 });
new BigNumber("3.43").toFraction("51").join("/");
// got:      "24/7"     (24/7  = 3.4285714...,  error 1.4286e-3)
// expected: "175/51"   (175/51 = 3.4313725...,  error 1.3725e-3)   <-- closer, denominator 51 ≤ 51
```

`175/51` is strictly closer to `3.43` than `24/7`, and `51 ≤ 51`, so `175/51` is the correct best approximation.

## Independent reference (Python `fractions`)

```python
>>> from fractions import Fraction
>>> Fraction("3.43").limit_denominator(51)
Fraction(175, 51)
>>> Fraction("-842.477").limit_denominator(725)
Fraction(-494534, 587)      # master returns -347943/413
>>> Fraction("968.761").limit_denominator(597)
Fraction(506662, 523)       # master returns 154033/159
```

I fuzzed **60,000** random values (positive/negative, integers, 1–15 fractional digits, `maxDenominator` up to 5000) against `Fraction(value).limit_denominator(md)`:
- **before:** hundreds of cases where the returned fraction was strictly farther from the value than the reference (with a denominator that was still ≤ `md`)
- **after:** 0 such cases — every result matches the reference error magnitude exactly.

## Root cause

`toFraction` builds the continued-fraction convergents, then picks between the last full convergent `n1/d1` and the semiconvergent `n0/d0` by deciding which is closer to `x`:

```js
e = e * 2;
r = div(n1, d1, e, ROUNDING_MODE).minus(x).abs().comparedTo(
    div(n0, d0, e, ROUNDING_MODE).minus(x).abs()) < 1 ? [n1, d1] : [n0, d0];
```

The two candidates are divided to only `e = 2 * (number of fractional digits of x)` decimal places before the differences are compared. For `3.43`, that is just 4 dp. Both candidates differ from `x` beyond the 4th decimal, so after rounding both `abs(diff)` values collapse to the same number, the comparison ties, and the `< 1` tie-break returns the wrong candidate `n1/d1`.

## Fix

Compare `abs(n1/d1 - x)` and `abs(n0/d0 - x)` **exactly** via cross-multiplication, using the exact value of `abs(x)` as `xn/xd` (where `xd` is the power of ten captured before the loop). All of `n1, d1, n0, d0, xn, xd` are non-negative at that point:

```
abs(n1/d1 - xn/xd) <= abs(n0/d0 - xn/xd)
  <=>  abs(n1*xd - xn*d1) * d0  <=  abs(n0*xd - xn*d0) * d1
```

This is exact for all inputs (no precision loss) and, as a side effect, makes the result independent of `ROUNDING_MODE`/`DECIMAL_PLACES` — which it should be, since `toFraction` returns an exact best approximation. The tie-break (prefer the last convergent `n1/d1`) is preserved, matching the behaviour of Python’s `limit_denominator`.

## Tests

Added 7 cases to `test/methods/toFraction.js` (expected values generated with Python’s `fractions` module). They fail on `master` and pass with the fix; the full suite (now 65,726 tests) passes.

> Note: `dist/` was intentionally **not** rebuilt/committed, matching the workflow of recent fix commits (e.g. #408) which touch only `bignumber.js` + tests.