### PR TITLE
Fix toFormat grouping by secondaryGroupSize when groupSize is 0

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -2765,7 +2765,8 @@ function clone(configObject) {
         fractionPart = arr[1],
         len = intPart.length;
 
-      if (g2) {
+      // A groupSize of 0 disables grouping, regardless of secondaryGroupSize.
+      if (g1 > 0 && g2) {
         i = g1;
         g1 = g2;
         g2 = i;

--- a/test/methods/toFormat.js
+++ b/test/methods/toFormat.js
@@ -279,6 +279,18 @@ Test('toFormat', function () {
 
     restoreDefaultFormat();
 
+    // groupSize: 0 must disable grouping even when secondaryGroupSize is set,
+    // instead of falling back to grouping by secondaryGroupSize alone.
+
+    BigNumber.config({ FORMAT: { groupSize: 0, secondaryGroupSize: 2 }});
+
+    t('123456789', 123456789);
+    t('1234.56', '1234.56');
+    t('-9.91', '-9.91');
+    t('1000037.123', '1000037.123456789', 3);
+
+    restoreDefaultFormat();
+
     //if (typeof window == 'undefined') {
     //    var vm = require('vm');
     //    t('1,234.57', '1234.567', vm.runInNewContext('[2, 2]'));


### PR DESCRIPTION
groupSize: 0 is supposed to disable grouping entirely (this was just fixed for the plain case in #407), but it doesn't work if `secondaryGroupSize` is also set. The two values get swapped internally for the Indian-style grouping logic, and the `groupSize > 0` check that's meant to short-circuit grouping ends up looking at the secondary value instead.

```js
BigNumber.config({ FORMAT: { groupSize: 0, secondaryGroupSize: 2 } });
new BigNumber(123456789).toFormat();   // '1,23,45,67,89' — should be '123456789'
```

Fixed by only doing the swap when the primary groupSize is actually greater than 0. Added tests next to the existing #407 cases, covering this combination.