### PR TITLE
Fix toFixed rounding 0 up to a power of ten at negative decimal places

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -1600,7 +1600,7 @@ function clone(configObject) {
           }
         }
 
-        r = r || sd < 0 ||
+        r = r || sd < 0 && xc[0] ||
 
         // Are there any non-zero digits after the rounding digit?
         // The expression  n % pows10[d - j - 1]  returns all digits of n to the right

--- a/dist/bignumber.cjs
+++ b/dist/bignumber.cjs
@@ -1600,7 +1600,7 @@ function clone(configObject) {
           }
         }
 
-        r = r || sd < 0 ||
+        r = r || sd < 0 && xc[0] ||
 
         // Are there any non-zero digits after the rounding digit?
         // The expression  n % pows10[d - j - 1]  returns all digits of n to the right

--- a/dist/bignumber.js
+++ b/dist/bignumber.js
@@ -1601,7 +1601,7 @@ function clone(configObject) {
           }
         }
 
-        r = r || sd < 0 ||
+        r = r || sd < 0 && xc[0] ||
 
         // Are there any non-zero digits after the rounding digit?
         // The expression  n % pows10[d - j - 1]  returns all digits of n to the right

--- a/dist/bignumber.mjs
+++ b/dist/bignumber.mjs
@@ -1600,7 +1600,7 @@ function clone(configObject) {
           }
         }
 
-        r = r || sd < 0 ||
+        r = r || sd < 0 && xc[0] ||
 
         // Are there any non-zero digits after the rounding digit?
         // The expression  n % pows10[d - j - 1]  returns all digits of n to the right

--- a/test/methods/toFixed.js
+++ b/test/methods/toFixed.js
@@ -1378,6 +1378,9 @@ Test('toFixed', function () {
     t('-1240', -1234.5, -1);
     t('-1300', -1234.5, -2);
     t('-2000', -1234.5, -3);
+    t('0', 0, -1);
+    t('0', 0, -100);
+    t('0', '-0', -3);
 
     // With rounding mode 1 (ROUND_DOWN)
     BigNumber.config({ROUNDING_MODE: 1});
@@ -1387,6 +1390,19 @@ Test('toFixed', function () {
     t('-1230', -1234.5, -1);
     t('-1200', -1234.5, -2);
     t('-1000', -1234.5, -3);
+
+    // With rounding mode 2 (ROUND_CEIL)
+    BigNumber.config({ROUNDING_MODE: 2});
+    t('1300', 1234.5, -2);
+    t('0', 0, -2);
+    t('0', '-0', -5);
+
+    // With rounding mode 3 (ROUND_FLOOR)
+    BigNumber.config({ROUNDING_MODE: 3});
+    t('1000', 1234.5, -3);
+    t('-2000', -1234.5, -3);
+    t('0', 0, -3);
+    t('0', '-0', -2);
 
     BigNumber.config({ROUNDING_MODE: 4});
 


### PR DESCRIPTION
`round()` computes the sticky/remainder flag as `r = r || sd < 0 || ...`. The `sd < 0` disjunct means "there are discarded digits to the right of the rounding position", which is correct for a non-zero value, but an **exact zero** has no digits at all, so the flag must stay false. Because it is forced true, `ROUND_UP` / `ROUND_CEIL` / `ROUND_FLOOR` round `0` away from zero and fabricate a power of ten.

`sd < 0` is reached from the public API through **negative decimal places** (added in #262), so this surfaces in `toFixed`, `decimalPlaces`/`dp` and `toFormat`:

```js
new BigNumber(0).toFixed(-2, 0)     // '100'    — should be '0'
new BigNumber(0).toFixed(-100, 0)   // 1e+100   — should be '0'
new BigNumber(0).toFixed(-2, 2)     // '100'  (ROUND_CEIL)
new BigNumber('-0').toFixed(-3, 3)  // '1000' (ROUND_FLOOR)
```

Rounding the exact value `0` to any number of places, in any mode, is `0` — every reference decimal (Java `BigDecimal`, Python `decimal`, .NET) agrees.

## Fix

Gate the disjunct on the value being non-zero: `sd < 0 && xc[0]`. `xc[0]` is `0` only when the value is zero — the same invariant the branch just below (`if (sd < 1 || !xc[0])`) already relies on. `&&` binds tighter than `||`, so the rest of the expression is unchanged, and non-zero values round exactly as before.

## Tests

Added zero-at-negative-dp cases to the existing ROUND_UP block and new ROUND_CEIL / ROUND_FLOOR blocks in `test/methods/toFixed.js`. They fail on the current code (`Expected: 0, Actual: 100`) and pass with the fix. Full suite: `65737 of 65737` passing. `dist/` rebuilt via `npm run build`.
